### PR TITLE
Update corrpart.b.R

### DIFF
--- a/R/corrpart.b.R
+++ b/R/corrpart.b.R
@@ -263,7 +263,13 @@ corrPartClass <- R6::R6Class(
                             icvx = solve(cvx)
 	                
 			# determine string for statistic (r, rho or tau)
-			statNm = ifelse(method == 'pearson', 'r', ifelse(method == 'spearman', 'rho', 'tau'))
+			if      (method == 'pearson')
+			    statNm <- 'r'
+			else if (method == 'spearman')
+			    statNm <- 'rho'
+			else if (method == 'kendall')
+			    statNm <- 'tau'
+
 	                # calculation of the partial correlation coefficient
 			if (type == 'part') {
                             results[[statNm, 1]] <- -cov2cor(icvx)[1, 2]


### PR DESCRIPTION
The code now permits to test directed hypotheses. Generally, the code changes are in .test and .compute. In addition, I did a little cleaning up (e.g., removed remaining leftovers from zero-order (type == 'zero') and occurrences where you assigned "larger" or "less" to hyp since they weren't used later).
Some comments:
[1] I tried to increase efficiency by calculating the results in one run and assigning it to the bottom and the upper part of the main diagonal in the results table at once.
[2] Following the approach taken in corrmatrix, I currently assign p = 1 if the proposed direction (e.g., negative) isn't fitting the sign of the correlation.
[3] I took some inspiration from the code in ppcor. I am a bit uncertain how to give credit for that. Either way, making a comment in the code as well as showing it as a reference below the results table is fine with me.